### PR TITLE
Use Retrofit to make first API call

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,7 @@ android {
 }
 
 ext {
-    retrofit_version = '2.3.0'
-    okhttp3_version = '3.8.1'
+    retrofit_version = '2.5.0'
     rxandroid_version = '2.0.1'
     rxkotlin_version = '2.1.0'
 }
@@ -69,12 +68,6 @@ dependencies {
 
     //JSON parser adapter for retrofit
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
-
-    //Simpler requests
-    implementation "com.squareup.okhttp3:okhttp:$okhttp3_version"
-
-    //Request Logger
-    implementation "com.squareup.okhttp3:logging-interceptor:$okhttp3_version"
 
     //Pretty Logger
     implementation 'com.orhanobut:logger:2.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,8 @@ dependencies {
 
     //JSON parser adapter for retrofit
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
+    // Scalars parser (string, etc.)
+    implementation "com.squareup.retrofit2:converter-scalars:$retrofit_version"
 
     //Pretty Logger
     implementation 'com.orhanobut:logger:2.1.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- To listen to network changes -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/ar/edu/itba/spi/calibracion/Activities/LoginActivity.kt
+++ b/app/src/main/java/ar/edu/itba/spi/calibracion/Activities/LoginActivity.kt
@@ -40,7 +40,7 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
      */
     private var mAuthTask: UserLoginTask? = null
 
-    // Make call disposable so we can cancel requests in case of app destruction with pending requests
+    // Use Disposable for API calls so we can cancel pending requests on destroy
     private var disposable: Disposable? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/ar/edu/itba/spi/calibracion/Activities/LoginActivity.kt
+++ b/app/src/main/java/ar/edu/itba/spi/calibracion/Activities/LoginActivity.kt
@@ -1,32 +1,35 @@
 package ar.edu.itba.spi.calibracion.Activities
 
+import android.Manifest.permission.READ_CONTACTS
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.annotation.TargetApi
-import android.content.pm.PackageManager
-import android.support.design.widget.Snackbar
-import android.support.v7.app.AppCompatActivity
 import android.app.LoaderManager.LoaderCallbacks
 import android.content.CursorLoader
 import android.content.Loader
+import android.content.pm.PackageManager
 import android.database.Cursor
 import android.net.Uri
 import android.os.AsyncTask
 import android.os.Build
 import android.os.Bundle
 import android.provider.ContactsContract
+import android.support.design.widget.Snackbar
+import android.support.v7.app.AppCompatActivity
 import android.text.TextUtils
+import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.widget.ArrayAdapter
 import android.widget.TextView
-
-import java.util.ArrayList
-import android.Manifest.permission.READ_CONTACTS
-import android.widget.AutoCompleteTextView
 import ar.edu.itba.spi.calibracion.R
-
+import ar.edu.itba.spi.calibracion.api.clients.PingClient
+import ar.edu.itba.spi.calibracion.api.defaultRetrofitInstance
+import ar.edu.itba.spi.calibracion.utils.TAG
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.Disposable
+import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_login.*
+import java.util.*
 
 /**
  * A login screen that offers login via email/password.
@@ -36,6 +39,9 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
      * Keep track of the login task to ensure we can cancel it if requested.
      */
     private var mAuthTask: UserLoginTask? = null
+
+    // Make call disposable so we can cancel requests in case of app destruction with pending requests
+    private var disposable: Disposable? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,6 +57,19 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
         })
 
         sign_in_button.setOnClickListener { attemptLogin() }
+
+        val retrofit = defaultRetrofitInstance
+        val client = retrofit.create(PingClient::class.java)
+        // API call, observed, with before-launch task https://medium.com/@elye.project/kotlin-and-retrofit-2-tutorial-with-working-codes-333a4422a890
+        disposable = client
+                .ping()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe { Log.d(TAG, "Pinging!") }
+                .subscribe(
+                    { result -> Log.d(TAG, result) },
+                    { error -> Log.e(TAG, error.message) }
+                )
     }
 
     private fun populateAutoComplete() {
@@ -217,6 +236,11 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
 
     override fun onLoaderReset(cursorLoader: Loader<Cursor>) {
 
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        disposable?.dispose()
     }
 
     object ProfileQuery {

--- a/app/src/main/java/ar/edu/itba/spi/calibracion/api/Defaults.kt
+++ b/app/src/main/java/ar/edu/itba/spi/calibracion/api/Defaults.kt
@@ -1,0 +1,39 @@
+package ar.edu.itba.spi.calibracion.api
+
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+const val API_BASE_URL = "https://pf-itba-spi.herokuapp.com"
+
+/**
+ * Lazily-initialized singleton of default HTTP client. **Use this instance whenever possible!**
+ */
+val httpClient: OkHttpClient by lazy {
+    OkHttpClient.Builder().build()
+}
+
+/**
+ * Default Retrofit builder. Uses [API_BASE_URL], [RxJava2CallAdapterFactory] to work with observables,
+ * and [ScalarsConverterFactory] to work with scalars (plain strings, etc.) and [MoshiConverterFactory]
+ * to work with JSON.  Also uses [the default HTTP client][httpClient].
+ */
+val defaultRetrofitBuilder: Retrofit.Builder by lazy {
+    Retrofit.Builder()
+            .baseUrl(API_BASE_URL)
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())  // Adapt calls to RXJava (observables, etc.)
+            .addConverterFactory(ScalarsConverterFactory.create())      // Work with plain strings, ints, etc.
+            .addConverterFactory(MoshiConverterFactory.create())        // Work with JSON
+            .client(httpClient)
+}
+
+/**
+ * Default Retrofit instance.  Uses defaults defined by [defaultRetrofitBuilder].
+ *
+ * @see defaultRetrofitBuilder
+ */
+val defaultRetrofitInstance: Retrofit by lazy {
+    defaultRetrofitBuilder.build()
+}

--- a/app/src/main/java/ar/edu/itba/spi/calibracion/api/clients/PingClient.kt
+++ b/app/src/main/java/ar/edu/itba/spi/calibracion/api/clients/PingClient.kt
@@ -1,0 +1,9 @@
+package ar.edu.itba.spi.calibracion.api.clients
+
+import io.reactivex.Observable
+import retrofit2.http.GET
+
+interface PingClient {
+    @GET("/ping")
+    fun ping(): Observable<String>
+}


### PR DESCRIPTION
Thanks to tutorial in https://medium.com/@elye.project/kotlin-and-retrofit-2-tutorial-with-working-codes-333a4422a890

- Add default API configuration and Retrofit instance
- Call the `ping` endpoint on API on app load
- Use Disposable
- Add scalar converters for Retrofit to work with plaintext endpoints